### PR TITLE
This allows support for openssh's -p option.

### DIFF
--- a/ssh.sh
+++ b/ssh.sh
@@ -31,7 +31,12 @@ if [ -z "${SSH}" ]
 then
 	telnet $*
 else
-	ssh $*
+    if [ -z "$2" ]
+    then 
+        ssh $*
+    else
+        ssh $1 -p $2
+    fi
 fi
 
 # EOB


### PR DESCRIPTION
This allows support for openssh's -p option (using a port other than 22). This is handy when wanting to connect to multiple hosts.

Usage: pconsole.sh myhost:port myhost2:port myhost3:port