### PR TITLE
clear stdin error status after ctrl-d

### DIFF
--- a/pconsole.c
+++ b/pconsole.c
@@ -59,7 +59,7 @@ char buf[256], *p;
 	fflush(stdout);
 
 	flags |= FLAGS_CMD_MODE;
-
+	/* clearerr(stdin); */ // or maybe here?
 	while((p = fgets(buf, 256, stdin)) != NULL) {
 		cstrip_line(buf);
 		if (*buf)
@@ -80,6 +80,7 @@ char buf[256], *p;
 			exit(0);
 		} else
 			printf("<Ctrl-D>\n");
+		clearerr(stdin);
 	}
 	flags &= ~FLAGS_CMD_MODE;
 


### PR DESCRIPTION
after reading ctrl-d from stdin in command mode to switch to console mode, the state (EOT) is saved and next return to command mode is instantly closed because of EOT state set on stdin. It means, after reading ctrl-d in command mode, the status EOT should be cleared to be able read commands again. Or maybe the command should be on line 62 before the while? You can decide yourself as I am no programmer and I am not sure, what's better. Thank you for great tool :+1: . Regards.